### PR TITLE
feat: small changes to public/private interface of the dice pkg

### DIFF
--- a/cmd/dice/main.go
+++ b/cmd/dice/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/johnmphillips/dice-roller/dice"
+)
+
+func main() {
+	// Roll 3d6
+	result, err := dice.Roll("3d6")
+	if err != nil {
+		panic(err)
+	}
+
+	// Print the total
+	fmt.Println(result.Total())
+}

--- a/dice/dice_roller.go
+++ b/dice/dice_roller.go
@@ -8,12 +8,31 @@ import (
 	"strconv"
 )
 
-type rollresult struct {
-	result int
-	rolls  []int
+// Result is the interface for the result of
+// one or more dice rolls
+type Result interface {
+	Rolls() []int
+	Total() int
 }
 
-func Roll(expression string) (*rollresult, error) {
+// result is the result of one or more dice
+// rolls
+type result struct {
+	total int
+	rolls []int
+}
+
+func (r *result) Total() int {
+	return r.total
+}
+
+// Rolls returns the individual rolls
+func (r *result) Rolls() []int {
+	return r.rolls
+}
+
+// Roll rolls the dice and returns the result if successful
+func Roll(expression string) (Result, error) {
 
 	re := regexp.MustCompile(`^([0-9]*)d([0-9]*)(kh|kl|!|)$`)
 
@@ -39,17 +58,15 @@ func Roll(expression string) (*rollresult, error) {
 		rolls = append(rolls, currentRoll)
 	}
 
-	total := 0
 	if advantage {
-		total = keepHighest(rolls)
-	} else if disadvantage {
-		total = keepLowest(rolls)
-	} else {
-		total = sum(rolls)
+		return &result{total: keepHighest(rolls), rolls: rolls}, nil
 	}
 
-	result := rollresult{rolls: rolls, result: total}
-	return &result, nil
+	if disadvantage {
+		return &result{total: keepLowest(rolls), rolls: rolls}, nil
+	}
+
+	return &result{rolls: rolls, total: sum(rolls)}, nil
 }
 
 func sum(rolls []int) int {

--- a/dice/dice_roller_test.go
+++ b/dice/dice_roller_test.go
@@ -16,8 +16,8 @@ func Test_RollsCorrectNumberOfDice(t *testing.T) {
 		expression := fmt.Sprintf("%dd%d", numberOfDice, diceSize)
 		result, _ := Roll(expression)
 
-		if len(result.rolls) != numberOfDice {
-			t.Errorf("%s: Expected %d dice to be rolled but got %d", expression, numberOfDice, len(result.rolls))
+		if len(result.Rolls()) != numberOfDice {
+			t.Errorf("%s: Expected %d dice to be rolled but got %d", expression, numberOfDice, len(result.Rolls()))
 		}
 	}
 
@@ -32,9 +32,9 @@ func Test_RollsCorrectSizeOfDice(t *testing.T) {
 		expression := fmt.Sprintf("%dd%d", numberOfDice, diceSize)
 		result, _ := Roll(expression)
 
-		for _, v := range result.rolls {
+		for _, v := range result.Rolls() {
 			if v > diceSize || v < 1 {
-				t.Errorf("%s: Dice values should be between 1 and %d. Got %v", expression, diceSize, result.rolls)
+				t.Errorf("%s: Dice values should be between 1 and %d. Got %v", expression, diceSize, result.Rolls())
 			}
 		}
 	}
@@ -51,12 +51,12 @@ func Test_RollSum(t *testing.T) {
 
 		sumOfRolls := 0
 
-		for _, v := range result.rolls {
+		for _, v := range result.Rolls() {
 			sumOfRolls += v
 		}
 
-		if result.result != sumOfRolls {
-			t.Errorf("%s: Result should equal the sum of the rolls. Got %v", expression, result.rolls)
+		if result.Total() != sumOfRolls {
+			t.Errorf("%s: Result should equal the sum of the rolls. Got %v", expression, result.Rolls())
 		}
 
 	}
@@ -73,14 +73,14 @@ func Test_RollKeepLowest(t *testing.T) {
 
 		lowestRoll := math.MaxInt
 
-		for _, v := range result.rolls {
+		for _, v := range result.Rolls() {
 			if v < lowestRoll {
 				lowestRoll = v
 			}
 		}
 
-		if result.result != lowestRoll {
-			t.Errorf("%s: Result should equal the lowest roll. Got %v", expression, result.rolls)
+		if result.Total() != lowestRoll {
+			t.Errorf("%s: Result should equal the lowest roll. Got %v", expression, result.Rolls())
 		}
 	}
 }
@@ -95,14 +95,14 @@ func Test_RollKeepHighest(t *testing.T) {
 
 		highestRoll := 0
 
-		for _, v := range result.rolls {
+		for _, v := range result.Rolls() {
 			if v > highestRoll {
 				highestRoll = v
 			}
 		}
 
-		if result.result != highestRoll {
-			t.Errorf("%s: Result should equal the highestRoll roll. Got %v", expression, result.rolls)
+		if result.Total() != highestRoll {
+			t.Errorf("%s: Result should equal the highestRoll roll. Got %v", expression, result.Rolls())
 		}
 	}
 }
@@ -123,16 +123,15 @@ func Test_RollExplodingDice(t *testing.T) {
 		result, _ := Roll("2d4!")
 		numberOfFours := 0
 
-		fmt.Printf("%+v\n", result)
-		for _, v := range result.rolls {
+		for _, v := range result.Rolls() {
 			if v == 4 {
 				numberOfFours++
 			}
 		}
 
 		want := numberOfFours + 2
-		if len(result.rolls) != want {
-			t.Errorf("Dice did not explode correctly: Wanted [%d total rolls] Got: [%d total rolls]", want, len(result.rolls))
+		if len(result.Rolls()) != want {
+			t.Errorf("Dice did not explode correctly: Wanted [%d total rolls] Got: [%d total rolls]", want, len(result.Rolls()))
 		}
 
 	}


### PR DESCRIPTION
## Changes

1. ⭐ Added `cmd/dice/main.go` to give example of public consumer of dice pkg
1. ♻️ Changed `rollresult` to `result` to follow idiomatic go variable naming conventions of either single word, lowercase camel, or pascal case
1. ♻️ Changed `Roll()` func to return a `Result` interface.
  3a. `Roll()` no longer returns pointer to internal `*result` type
1. ♻️ Changed `if else` statements in `Roll()` into early returns to follow the Go "happy path" and be more idiomatic
2. 🔥 Removed instantiation of var `total` in favor of assigning total directly to `result` struct in return statement
3. ♻️ Updated tests to work with new changes to `Result` interface

## Details

Your Go code looks really good! For the most part it seems pretty much like idiomatic Go. I tweaked things to either follow Go conventions or to make it more friendly to consume as a public pkg. 

For example, by using a `Result` interface that offers two public methods, `Total()` and `Rolls()`, you are free to change your internal `result` business logic as much as you please because users of the `dice` pkg are only reliant on those two public methods offered by Result instead of building their code assuming all the fields in the internal type `result` will always be there.

It creates a split between your public API surface and your internal one; just keeps things nice and tidy to maintain.